### PR TITLE
docs: update README voor developer publiek

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ After execution, the generated prediction files will be saved in `models/predict
 ## Contributors
 Thank you to all the people who have already contributed to Uitnodigingsregel [[contributors](https://github.com/cedanl/Uitnodigingsregel/graphs/contributors)].
 
-[![](https://github.com/tin900.png?size=50)](https://github.com/tin900)
-[![](https://github.com/MondriaanBI.png?size=50)](https://github.com/MondriaanBI)
-[![](https://github.com/asewnandan.png?size=50)](https://github.com/asewnandan)
-[![](https://github.com/StevenRamondt.png?size=50)](https://github.com/StevenRamondt)
+<a href="https://github.com/tin900"><img src="https://github.com/tin900.png" width="50" height="50" alt="tin900"></a>
+<a href="https://github.com/MondriaanBI"><img src="https://github.com/MondriaanBI.png" width="50" height="50" alt="MondriaanBI"></a>
+<a href="https://github.com/asewnandan"><img src="https://github.com/asewnandan.png" width="50" height="50" alt="asewnandan"></a>
+<a href="https://github.com/StevenRamondt"><img src="https://github.com/StevenRamondt.png" width="50" height="50" alt="StevenRamondt"></a>
+
 
 ## Credits
 This product was originally created with [Cookiecutter Data Science](https://github.com/drivendataorg/cookiecutter-data-science) and migrated to the [CEDA package standard](https://github.com/cedanl/.github/tree/main/standards).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Volledige documentatie, pipeline-overzicht en projectstructuur: **[cedanl.github
 
 ## Datavoorbereiding
 
-SQL-voorbeeldcode voor de invoerdata wisbeschikbaar via de [Uitnodigingsregel_datapreparatie](https://github.com/cedanl/Uitnodigingsregel_datapreparatie) repo. Zorg dat de voorbereide data aanwezig is in `data/02-prepared/` voordat je de pipeline draait. Of gebruik de synthetische demo-data.
+SQL-voorbeeldcode voor de invoerdata is beschikbaar via de [Uitnodigingsregel_datapreparatie](https://github.com/cedanl/Uitnodigingsregel_datapreparatie) repo. Zorg dat de voorbereide data aanwezig is in `data/02-prepared/` voordat je de pipeline draait. Of gebruik de synthetische demo-data.
 
 Een overzicht van alle variabelen staat in de [data dictionary](docs/Variabelen_Definities_v4.xlsx).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Studenten uitval voorspellen
+# Uitnodigingsregel
+
+Python implementatie van de Uitnodigingsregel — een machine learning model dat studenten met een verhoogd uitvalrisico signaleert. Bedoeld voor data scientists en developers die het model opzetten en beheren binnen hun onderwijsinstelling.
 
 # Waarom de Uitnodigingsregel
 Onderwijsinstellingen worstelen al jaren om meer grip op uitval te krijgen. Steeds vaker wordt hierbij gebruikgemaakt van data over de studieontwikkeling van studenten.
@@ -20,44 +22,15 @@ Meer informatie over het voorkomen van studentenuitval door middel van verklarin
 Wil je de Uitnodigingsregel toepassen binnen jouw onderwijsinstelling? Houd dan rekening met een uitgebreide voorbereiding, waaronder een DPIA (Data Protection Impact Assessment) maar ook ethische toetsing en toetsing aan de AI-verordening. De Datacoalitie Datagedreven Onderzoek heeft deze methodiek zorgvuldig naar de praktijk vertaald. Lees [hier meer](https://datagedrevenonderzoekmbo.nl/themas/voorspelmodel) over dit proces en bekijk de [ontwikkelde producten](https://datagedrevenonderzoekmbo.nl/themas/voorspelmodel/praktijkpilot-de-uitnodigingsregel) die kunnen helpen bij een succesvolle implementatie van de Uitnodigingsregel.
 
 
-# Student dropout model
+# Aan de slag
 
-## Project Structure
+Volledige documentatie, pipeline-overzicht en projectstructuur: **[cedanl.github.io/Uitnodigingsregel](https://cedanl.github.io/Uitnodigingsregel/)**
 
-```
-├── LICENSE
-├── Makefile                     <- Convenience commands
-├── README.md
-├── main.py                      <- Pipeline entrypoint
-├── Model_analysis.qmd           <- Quarto analysis report
-├── config.yaml                  <- Root configuration
-├── data/
-│   ├── 01-raw/                  <- Original, immutable data
-│   │   ├── demo/                <- Synthetic demo data (committed)
-│   │   └── user_data/           <- User-provided data (gitignored)
-│   ├── 02-prepared/             <- Standardized intermediate data
-│   └── 03-output/               <- Processed datasets
-├── models/                      <- Trained models (.joblib) and predictions
-│   └── predictions/             <- Output files
-├── reports/                     <- Generated analysis (HTML, figures)
-│   └── figures/
-├── src/uitnodigingsregel/       <- Installable Python package
-│   ├── dataset.py               <- Data cleaning (deduplication, imputation)
-│   ├── features.py              <- Feature engineering
-│   ├── evaluate.py              <- Model evaluation and settings
-│   ├── visualize.py             <- Plotting functions
-│   ├── analyze.py               <- Analysis helpers
-│   ├── modeling/
-│   │   ├── train.py             <- Model training (RF, Lasso, SVM)
-│   │   └── predict.py           <- Model prediction
-│   └── metadata/
-│       └── config.yaml          <- Hyperparameters and settings
-├── app/                         <- Streamlit interactive app
-│   ├── main.py
-│   └── config.toml
-├── tests/                       <- Unit tests
-└── pyproject.toml               <- Project configuration
-```
+## Datavoorbereiding
+
+De invoerdata wordt voorbereid via de [Uitnodigingsregel_datapreparatie](https://github.com/cedanl/Uitnodigingsregel_datapreparatie) repo. Zorg dat de voorbereide data aanwezig is in `data/02-prepared/` voordat je de pipeline draait.
+
+Een overzicht van alle variabelen staat in de [data dictionary](docs/Variabelen_Definities_v4.xlsx).
 
 ## Prerequisites
 If you do not have a Python environment set up, follow these steps:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Volledige documentatie, pipeline-overzicht en projectstructuur: **[cedanl.github
 
 ## Datavoorbereiding
 
-De invoerdata wordt voorbereid via de [Uitnodigingsregel_datapreparatie](https://github.com/cedanl/Uitnodigingsregel_datapreparatie) repo. Zorg dat de voorbereide data aanwezig is in `data/02-prepared/` voordat je de pipeline draait.
+SQL-voorbeeldcode voor de invoerdata wisbeschikbaar via de [Uitnodigingsregel_datapreparatie](https://github.com/cedanl/Uitnodigingsregel_datapreparatie) repo. Zorg dat de voorbereide data aanwezig is in `data/02-prepared/` voordat je de pipeline draait. Of gebruik de synthetische demo-data.
 
 Een overzicht van alle variabelen staat in de [data dictionary](docs/Variabelen_Definities_v4.xlsx).
 


### PR DESCRIPTION
## Summary

- Openingszin toegevoegd: wat is het, voor wie is het
- Project Structure sectie verwijderd — staat nu in [docs/aan-de-slag.md](https://cedanl.github.io/Uitnodigingsregel/aan-de-slag/)
- Verwijzing naar [Uitnodigingsregel_datapreparatie](https://github.com/cedanl/Uitnodigingsregel_datapreparatie) als upstream datastap
- Verwijzing naar data dictionary (`docs/Variabelen_Definities_v4.xlsx`)
- Link naar MkDocs documentatiesite voor volledig overzicht

Closes #7
Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)