### PR TITLE
fix: update scoop hash naar werkelijke v0.1.0 tarball hash

### DIFF
--- a/bucket/uitnodigingsregel.json
+++ b/bucket/uitnodigingsregel.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "depends": "uv",
     "url": "https://github.com/cedanl/Uitnodigingsregel/archive/refs/tags/v$version.tar.gz",
-    "hash": "sha256:d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed",
+    "hash": "sha256:4ab5b11ef68978029ff053c60992d1660989f5d3262a46d63d7c877c2f2f2501",
     "extract_dir": "Uitnodigingsregel-$version",
     "installer": {
         "script": [


### PR DESCRIPTION
## Summary
- Hash in `bucket/uitnodigingsregel.json` klopte niet met de werkelijke SHA256 van de v0.1.0 tarball
- Scoop weigerde te installeren met een 404-fout ondanks dat de tarball-URL zelf werkt
- Hash gecorrigeerd naar de werkelijke waarde

Closes #53