### PR TITLE
fix: maak .cmd bestand aan in installer ipv post_install

### DIFF
--- a/bucket/uitnodigingsregel.json
+++ b/bucket/uitnodigingsregel.json
@@ -9,7 +9,8 @@
     "extract_dir": "Uitnodigingsregel-0.1.0",
     "installer": {
         "script": [
-            "uv sync --directory \"$dir\""
+            "uv sync --directory \"$dir\"",
+            "@('@echo off', 'uv run --directory \"%~dp0\" uitnodigingsregel %*') | Set-Content \"$dir\\uitnodigingsregel.cmd\""
         ]
     },
     "uninstaller": {
@@ -18,12 +19,6 @@
         ]
     },
     "bin": "uitnodigingsregel.cmd",
-    "post_install": [
-        "Set-Content \"$dir\\uitnodigingsregel.cmd\" @\"",
-        "@echo off",
-        "uv run --directory \"%~dp0\" uitnodigingsregel %*",
-        "\"@"
-    ],
     "autoupdate": {
         "url": "https://github.com/cedanl/Uitnodigingsregel/archive/refs/tags/v$version.zip",
         "extract_dir": "Uitnodigingsregel-$version",


### PR DESCRIPTION
## Summary
- Scoop volgorde: `installer` → shim aanmaken → `post_install`
- `.cmd` bestand werd in `post_install` aangemaakt, maar Scoop probeerde het al te shimmen in de vorige stap → `File doesn't exist` fout
- `.cmd` aanmaken verplaatst naar `installer.script` zodat het bestaat vóór de shim
- `post_install` verwijderd

Closes #55