### PR TITLE
fix: scoop manifest werkend maken op Windows

### DIFF
--- a/bucket/uitnodigingsregel.json
+++ b/bucket/uitnodigingsregel.json
@@ -10,7 +10,7 @@
     "installer": {
         "script": [
             "uv sync --directory \"$dir\"",
-            "@('@echo off', 'uv run --directory \"%~dp0\" uitnodigingsregel %*') | Set-Content \"$dir\\uitnodigingsregel.cmd\""
+            "@('@echo off', 'uv run --directory \"%~dp0.\" uitnodigingsregel %*') | Set-Content \"$dir\\uitnodigingsregel.cmd\""
         ]
     },
     "uninstaller": {


### PR DESCRIPTION
## Summary
- Hardcode versie in `url` en `extract_dir` (`$version` werkt niet in het url-veld van Scoop)
- `.cmd` bestand aanmaken in `installer.script` i.p.v. `post_install` (Scoop shim-volgorde: installer → shim → post_install)
- `%~dp0.` gebruiken i.p.v. `%~dp0` om trailing backslash quoting-bug te vermijden (Windows error 123)
- `autoupdate` sectie toegevoegd voor toekomstige versie-updates
- `post_install` verwijderd

Closes #55